### PR TITLE
fix: job stats reset

### DIFF
--- a/EasyLib/Job/Job.cs
+++ b/EasyLib/Job/Job.cs
@@ -126,6 +126,12 @@ public class Job(
     /// <returns>True when the job is complete</returns>
     private bool Start(bool resume)
     {
+        // If the job is already running, return false
+        if (CurrentlyRunning)
+        {
+            return false;
+        }
+
         // Wait for the company software to be closed
         if (ConfigManager.Instance.CheckProcessRunning())
         {


### PR DESCRIPTION
Differentiate job run and resume, and reset the in-memory stats if it's a run